### PR TITLE
Bugfix/c2000 crc

### DIFF
--- a/lib/atca_config.h
+++ b/lib/atca_config.h
@@ -8,13 +8,35 @@
 #include <string.h>
 
 #define UINT8_MAX 0xFF
-#define ATCA_UINT16_HOST_TO_BE(x)  (x)
-#define ATCA_UINT32_HOST_TO_BE(x)  (x)
-#define ATCA_UINT64_HOST_TO_BE(x)  (x)
-#define ATCA_UINT16_HOST_TO_LE(x)  (((x >> 8) & 0xFF) | ((x << 8) & 0xFF))
-#define ATCA_UINT32_HOST_TO_LE(x)  (x)
 
-#define ATCA_UINT32_BE_TO_HOST(x)   (x)
+
+/* The cryptolib was not prepared for c2000 insanity so there is some 
+ subtlety to how to convert these. In the 16bit word wonderland a uint32_t
+ in memory exists as follows:
+ Actual value in big endian:        0xAABBCCDD
+ Memory view as stored in c2000:    CCDD AABB
+ 
+ That means we ALSO need some conversion for the little endian macros since each
+ word is big endian bitwise, even though the architecture is little endian.
+ */
+// Verified / Used macros
+#define ATCA_UINT16_HOST_TO_LE(x)  ( ((x & 0xFF) << 8) | ((x & 0xFF00) >> 8) )
+
+// Unverified
+#define ATCA_UINT16_HOST_TO_BE(x)  ( ((x & 0xFF) << 8) | ((x & 0xFF00) >> 8) )
+#define ATCA_UINT16_BE_TO_HOST(x)  ( ((x & 0xFF) << 8) | ((x & 0xFF00) >> 8) )
+#define ATCA_UINT16_LE_TO_HOST(x)  (x)
+#define ATCA_UINT32_HOST_TO_LE(x)  (x)
+#define ATCA_UINT32_HOST_TO_BE(x)  ( ((x & 0xFF) << 24) | ((x & 0xFF00) << 8) | ((x & 0xFF0000) >> 8) | ((x & 0xFF000000) >> 24))
+#define ATCA_UINT32_BE_TO_HOST(x)  ( ((x & 0xFF) << 24) | ((x & 0xFF00) << 8) | ((x & 0xFF0000) >> 8) | ((x & 0xFF000000) >> 24))
+#define ATCA_UINT64_HOST_TO_BE(x)  ( ((x & 0xFF) << 56) | ((x & 0xFF00) << 40) |\
+                                     ((x & 0xFF0000) << 24) | ((x & 0xFF000000) << 8) |\
+                                     ((x & 0xFF00000000) >> 8) | ((x & 0xFF0000000000) >> 24) |\
+                                     ((x & 0xFF000000000000) >> 40) | ((x & 0xFF00000000000000) >> 56))
+#define ATCA_UINT64_BE_TO_HOST(x)  ( ((x & 0xFF) << 56) | ((x & 0xFF00) << 40) |\
+                                     ((x & 0xFF0000) << 24) | ((x & 0xFF000000) << 8) |\
+                                     ((x & 0xFF00000000) >> 8) | ((x & 0xFF0000000000) >> 24) |\
+                                     ((x & 0xFF000000000000) >> 40) | ((x & 0xFF00000000000000) >> 56))
 
 
 /* Included HALS */
@@ -23,7 +45,6 @@
 // #undef ATCA_HAL_I2C
 #undef ATCA_HAL_SPI
 #undef ATCA_HAL_KIT_BRIDGE
-#define ATCA_HAL_CUSTOM
 #undef ATCA_HAL_SWI_UART
 #undef ATCA_HAL_1WIRE
 
@@ -35,19 +56,13 @@
 
 #define ATCA_NO_PRAGMA_PACK
 
-/** Device Override - Library Assumes ATECC608B support in checks */
-/* #undef ATCA_ATECC608A_SUPPORT */
-
-/** Define to enable compatibility with legacy HALs
-   (HALs with embedded device logic)*/
-/* #undef ATCA_HAL_LEGACY_API */
-
 /** To use dynamically registered HALs without any of the provided
 implementations its necessary to specify a value here - using this
 in addition to specifying a provide hal may result in compilation
 problems - it will need to be the same as the number of the hal options
 selected plus however additional slots one would like */
 /* #undef ATCA_MAX_HAL_CACHE */
+#define ATCA_MAX_HAL_CACHE 1
 
 /** Define if cryptoauthlib is to use the maximum execution time method */
 /* #undef ATCA_NO_POLL */
@@ -125,8 +140,6 @@ selected plus however additional slots one would like */
 /** Enables multipart buffer handling (generally for small memory model platforms) */
 #define MULTIPART_BUF_EN 0
 
-//#define ATCA_NO_POLL
-
 /******************** Platform Configuration Section ***********************/
 
 /** Define if the library is not to use malloc/free */
@@ -139,7 +152,6 @@ selected plus however additional slots one would like */
 
 /* #undef ATCA_PLATFORM_MEMSET_S */
 
-#define atca_delay_ms   hal_delay_ms
 #define atca_delay_us   DEVICE_DELAY_US
 
 #endif // ATCA_CONFIG_H

--- a/lib/calib/calib_basic.c
+++ b/lib/calib/calib_basic.c
@@ -50,7 +50,7 @@ ATCA_STATUS calib_wakeup_i2c(ATCADevice device)
 
         do
         {
-            if (100000u < ATCA_IFACECFG_VALUE(iface->mIfaceCFG, atcai2c.baud))
+            if (100000u <= ATCA_IFACECFG_VALUE(iface->mIfaceCFG, atcai2c.baud))
             {
                 temp = 100000u;
                 status = atcontrol(iface, (uint8_t)ATCA_HAL_CHANGE_BAUD, &temp, sizeof(temp));

--- a/lib/calib/calib_command.h
+++ b/lib/calib/calib_command.h
@@ -202,7 +202,7 @@ ATCA_STATUS isATCAError(uint8_t *data);
 
 
 // command helpers
-void atCRC(size_t length, const uint8_t *data, uint8_t *crc_le);
+void atCRC(size_t length, const uint8_t *data, uint8_t *crc_le, bool isTx);
 void atCalcCrc(ATCAPacket *packet);
 ATCA_STATUS atCheckCrc(const uint8_t *response);
 


### PR DESCRIPTION
# Please describe the purpose of this pull request
- Updates to config for c2000 builds:
  - Fix endianess macros (that are used)
  - Move from custom HAL to no preset HAL (now registered during init)
- Fix CRC issues
  - Fix errors caused by word size differences for c2000 and how cryptoauthlib uses packet structure. This only occurs in messages that are sent to the device (only time uint16 value is used), so also account for tx vs rx calculation of crc.