### PR TITLE
Resolved issue related to sizeof() on C2000 target used in wake()

### DIFF
--- a/lib/calib/calib_basic.c
+++ b/lib/calib/calib_basic.c
@@ -45,7 +45,7 @@ ATCA_STATUS calib_wakeup_i2c(ATCADevice device)
         int retries = atca_iface_get_retries(iface);
         uint8_t address = atcab_get_device_address(device);
         uint32_t temp;
-        uint32_t wake;
+        uint_least8_t wake[4];
         uint16_t rxlen;
 
         do


### PR DESCRIPTION
This PR fixes an issue in sending wakeup to ATECC608B - specifically the code which reads back status afterwards.  It was attempting to read back 4 bytes (len, status, 2 bytes of CRC) into a uint32.  However, on the C2000 target, sizeof (uint32) = 2, and so the status was being read back incorrectly, and the wake was failing.

Task [KKN-128 (loading ATECC608B with public keys and performing ECDSA verification using those stored keys) ](https://generacet.atlassian.net/browse/KKN-128)depends on this fix.
