### PR TITLE
Removed manual pdf

### DIFF
--- a/cryptoauthlib-manual.pdf
+++ b/cryptoauthlib-manual.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8be6a1ff8a5e111274869b675ea90c8f94592ddf325ecb25ba3370be93c4f9ed
-size 2443607


### PR DESCRIPTION
# Please describe the purpose of this pull request
- The removed PDF was being modified during CI builds, leading to dirty builds.
- Unclear why this was happening, short term workaround is to remove the file.


# Checklist
* [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
